### PR TITLE
Update React import to glob.

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -7,7 +7,7 @@ import {
 } from "./types";
 import { createRouter as coreCreateRouter, parseArgs } from "./createRouter";
 import { TypeRouteError } from "./TypeRouteError";
-import React from "react";
+import * as React from "react";
 import { attemptScrollToTop } from "./attemptScrollToTop";
 
 if (typeof __DEV__ === "boolean" && __DEV__) {


### PR DESCRIPTION
The build pipeline we're using is making the constraints on our dependencies, however typed-route is so important (and well liked) that it's not really a choice here. 

Further explanation: 
The dependency is a `module` but is using CJS imports. 
We're getting `type-route.esm.js` (notice the `ESM` extension)  in our build pipeline since we're prioritizing module packages over legacy ones (and we should!) but it can't be using CJS imports. 
